### PR TITLE
Update o365.json

### DIFF
--- a/rules/detection/high/o365.json
+++ b/rules/detection/high/o365.json
@@ -85,5 +85,10 @@
     "type": "o365",
     "reference" : "https://outline.cybersift.io/s/engineering/doc/suspicious-outlook-mobile-silent-authentication-cmsi-MutnSbauyx"
   }
-  
+  {
+    "title": "Suspicious Outlook Office Authentication  Interupt (CMSI)",
+    "expression": "event.action == 'UserLoginFailed' && o365.audit.LogonError == 'CmsiInterrupt'",
+    "severity": "high",
+    "type": "o365"
+  }
 ]


### PR DESCRIPTION
CmsiInterrupt check
 Detection Description: Suspicious Outlook Office Authentication Interrupt (CMSI)
This detection identifies instances where a Microsoft Office login attempt (typically via Outlook) was interrupted by a Conditional Access Microsoft Sentinel Interrupt (CMSI).

What is a CMSI Interrupt?
A CmsiInterrupt occurs when an authentication request successfully passes the initial credential check but is blocked or "interrupted" by a specific Conditional Access (CA) policy. Unlike a standard "wrong password" error, this indicates that the user's context triggered a security boundary set by your organization.