### PR TITLE
attempting cname record for user friendly rules domain

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+rules.cybersift.io


### PR DESCRIPTION
I am trying to provision https://rules.cybersift.io to point to the newly created github page